### PR TITLE
qemu: Update RX helpers patch

### DIFF
--- a/.github/workflows/build-crosstool-ng.yaml
+++ b/.github/workflows/build-crosstool-ng.yaml
@@ -2,8 +2,20 @@ name: Build Toolchains with crosstool-ng
 
 on:
   push:
+    branches:
+      - main
+    tags:
+      - '*'
   pull_request:
+    branches:
+      - main
   workflow_dispatch:
+
+# When a PR is updated, cancel the jobs from the previous version. Merges
+# do not define head_ref, so use run_id to never cancel those jobs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
 permissions:
     contents: write

--- a/.github/workflows/build-qemu.yaml
+++ b/.github/workflows/build-qemu.yaml
@@ -2,8 +2,20 @@ name: Build QEMU
 
 on:
   push:
+    branches:
+      - main
+    tags:
+      - '*'
   pull_request:
+    branches:
+      - main
   workflow_dispatch:
+
+# When a PR is updated, cancel the jobs from the previous version. Merges
+# do not define head_ref, so use run_id to never cancel those jobs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
 permissions:
     contents: write

--- a/patches/qemu/9.2.0/0005-target-rx-Remove-TCG_CALL_NO_WG-from-helpers-which-w.patch
+++ b/patches/qemu/9.2.0/0005-target-rx-Remove-TCG_CALL_NO_WG-from-helpers-which-w.patch
@@ -1,4 +1,4 @@
-From 509a40a409c06e740547c02604b4dccb4c8f31ae Mon Sep 17 00:00:00 2001
+From 04ffd1818c3939dc2c35552fda2d7e306f2ff80c Mon Sep 17 00:00:00 2001
 From: Keith Packard <keithp@keithp.com>
 Date: Fri, 14 Feb 2025 18:02:08 -0800
 Subject: [PATCH 5/5] target/rx: Remove TCG_CALL_NO_WG from helpers which write
@@ -8,20 +8,38 @@ Functions which modify virtual machine state (such as virtual
 registers stored in memory) must not be marked TCG_CALL_NO_WG as that
 tells the optimizer that virtual registers values already loaded in
 machine registers are still valid, hence discards any changes which
-these helpers may have made.
+these helpers may have made. This seems to also mean that functions which
+set condition codes may also not use this flag
 
 Signed-off-by: Keith Packard <keithp@keithp.com>
 ---
- target/rx/helper.h | 14 +++++++-------
- 1 file changed, 7 insertions(+), 7 deletions(-)
+ target/rx/helper.h | 34 +++++++++++++++++-----------------
+ 1 file changed, 17 insertions(+), 17 deletions(-)
 
 diff --git a/target/rx/helper.h b/target/rx/helper.h
-index ebb4739474..ac21f4fddd 100644
+index ebb4739474..8cc38b0cb7 100644
 --- a/target/rx/helper.h
 +++ b/target/rx/helper.h
-@@ -13,18 +13,18 @@ DEF_HELPER_FLAGS_2(ftoi, TCG_CALL_NO_WG, i32, env, f32)
- DEF_HELPER_FLAGS_2(round, TCG_CALL_NO_WG, i32, env, f32)
- DEF_HELPER_FLAGS_2(itof, TCG_CALL_NO_WG, f32, env, i32)
+@@ -4,27 +4,27 @@ DEF_HELPER_1(raise_privilege_violation, noreturn, env)
+ DEF_HELPER_1(wait, noreturn, env)
+ DEF_HELPER_2(rxint, noreturn, env, i32)
+ DEF_HELPER_1(rxbrk, noreturn, env)
+-DEF_HELPER_FLAGS_3(fadd, TCG_CALL_NO_WG, f32, env, f32, f32)
+-DEF_HELPER_FLAGS_3(fsub, TCG_CALL_NO_WG, f32, env, f32, f32)
+-DEF_HELPER_FLAGS_3(fmul, TCG_CALL_NO_WG, f32, env, f32, f32)
+-DEF_HELPER_FLAGS_3(fdiv, TCG_CALL_NO_WG, f32, env, f32, f32)
+-DEF_HELPER_FLAGS_3(fcmp, TCG_CALL_NO_WG, void, env, f32, f32)
+-DEF_HELPER_FLAGS_2(ftoi, TCG_CALL_NO_WG, i32, env, f32)
+-DEF_HELPER_FLAGS_2(round, TCG_CALL_NO_WG, i32, env, f32)
+-DEF_HELPER_FLAGS_2(itof, TCG_CALL_NO_WG, f32, env, i32)
++DEF_HELPER_3(fadd, f32, env, f32, f32)
++DEF_HELPER_3(fsub, f32, env, f32, f32)
++DEF_HELPER_3(fmul, f32, env, f32, f32)
++DEF_HELPER_3(fdiv, f32, env, f32, f32)
++DEF_HELPER_3(fcmp, void, env, f32, f32)
++DEF_HELPER_2(ftoi, i32, env, f32)
++DEF_HELPER_2(round, i32, env, f32)
++DEF_HELPER_2(itof, f32, env, i32)
  DEF_HELPER_2(set_fpsw, void, env, i32)
 -DEF_HELPER_FLAGS_2(racw, TCG_CALL_NO_WG, void, env, i32)
 -DEF_HELPER_FLAGS_2(set_psw_rte, TCG_CALL_NO_WG, void, env, i32)
@@ -30,9 +48,11 @@ index ebb4739474..ac21f4fddd 100644
 +DEF_HELPER_2(set_psw_rte, void, env, i32)
 +DEF_HELPER_2(set_psw, void, env, i32)
  DEF_HELPER_1(pack_psw, i32, env)
- DEF_HELPER_FLAGS_3(div, TCG_CALL_NO_WG, i32, env, i32, i32)
- DEF_HELPER_FLAGS_3(divu, TCG_CALL_NO_WG, i32, env, i32, i32)
+-DEF_HELPER_FLAGS_3(div, TCG_CALL_NO_WG, i32, env, i32, i32)
+-DEF_HELPER_FLAGS_3(divu, TCG_CALL_NO_WG, i32, env, i32, i32)
 -DEF_HELPER_FLAGS_1(scmpu, TCG_CALL_NO_WG, void, env)
++DEF_HELPER_3(div, i32, env, i32, i32)
++DEF_HELPER_3(divu, i32, env, i32, i32)
 +DEF_HELPER_1(scmpu, void, env)
  DEF_HELPER_1(smovu, void, env)
  DEF_HELPER_1(smovf, void, env)


### PR DESCRIPTION
Looks like more helpers functions need the TCG_CALL_NO_WG flag disabled. I've disabled it on all of these; that will just make some code run a bit slower.