### PR TITLE
ci: add custom QEMU 11.0.2 build for RISC-V

### DIFF
--- a/.github/workflows/build-qemu.yaml
+++ b/.github/workflows/build-qemu.yaml
@@ -49,6 +49,11 @@ jobs:
             target-list: "hexagon-softmmu"
             repository: quic/qemu
             ref: hex-next
+          - variant: riscv # 11.0.2
+            target-list: "riscv32-softmmu,riscv64-softmmu"
+            repository: qemu/qemu
+            ref: v11.0.2
+            extra-args: "--enable-relocatable"
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Build riscv32-softmmu and riscv64-softmmu as qemu-riscv so picolibc CI
can use a fixed QEMU version instead of Debian unstable. QEMU 11.0.2 is
the first release with the zicfilp menvcfg access fix needed for CFI testing.