### PR TITLE
Revert "ci: add custom QEMU 11.0.2 build for RISC-V"

### DIFF
--- a/.github/workflows/build-qemu.yaml
+++ b/.github/workflows/build-qemu.yaml
@@ -49,11 +49,6 @@ jobs:
             target-list: "hexagon-softmmu"
             repository: quic/qemu
             ref: hexagon-sysemu-23-apr-2026
-          - variant: riscv # 11.0.2
-            target-list: "riscv32-softmmu,riscv64-softmmu"
-            repository: qemu/qemu
-            ref: v11.0.2
-            extra-args: "--enable-relocatable"
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This reverts commit 6c57f4d005625acc6b7c14919d9c2fad6e2d016e.

As debian unstable contains this qemu version, we don't need our own build anymore.